### PR TITLE
Arrumado erro em registro de owner

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,9 @@
+class Users::RegistrationsController < Devise::RegistrationsController
+    protected
+
+    def sign_up_params
+        params = devise_parameter_sanitizer.sanitize(:sign_up)
+        params["owner"] = true
+        params
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: { registrations: "users/registrations" }
   devise_for :admins
 
   resources :payment_methods, only: %i[new create show destroy index]

--- a/spec/system/user/visitor_registers_as_user_spec.rb
+++ b/spec/system/user/visitor_registers_as_user_spec.rb
@@ -11,6 +11,9 @@ describe 'Visitor registers as user' do
     click_on 'commit'
 
     expect(page).to have_content('Login efetuado com sucesso')
+    expect(page).to have_content('Você já se cadastrou no nosso sistema, mas '\
+      'agora precisa registrar a sua empresa! Preencha os dados abaixo para '\
+      'podermos conhecer sua empresa:')
   end
 
   it 'and fails when using a public email domain' do


### PR DESCRIPTION
Não tinha nada errado com as funcionalidades do model user  em si, mas se registrar como usuário(dono de empresa) não dava o atributo owner a ele, que era necessário para que o fluxo do sistema fizesse sentido. A PR faz essa pequena mudança e adiciona um teste para garantir que esse erro não ocorra novamente.