### PR TITLE
Add customer payment method to customer show

### DIFF
--- a/app/controllers/api/v1/customer_controller.rb
+++ b/app/controllers/api/v1/customer_controller.rb
@@ -17,7 +17,10 @@ module Api
 
         render status: :ok, json: @customer.as_json(except: %i[id company_id
                                                                created_at updated_at],
-                                                    include: { company: { only: :legal_name } })
+                                                    include: {
+                                                      company: { only: :legal_name },
+                                                      customer_payment_methods: { only: %i[name token] }
+                                                    })
       end
 
       def create

--- a/app/controllers/api/v1/customer_payment_method_controller.rb
+++ b/app/controllers/api/v1/customer_payment_method_controller.rb
@@ -19,7 +19,7 @@ module Api
         @customer = Customer.find_by(token: customer_payment_method_params[:customer_token], company: @company)
 
         @customer_payment_method = CustomerPaymentMethod.new(
-          payment_method: @payment_method, customer: @customer, company: @company
+          payment_method: @payment_method, customer: @customer, company: @company, name: @payment_method&.type_of
         )
         @customer_payment_method.add_credit_card(credit_card_params) if @payment_method&.credit_card?
 

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -1,5 +1,6 @@
 class Customer < ApplicationRecord
   belongs_to :company
+  has_many :customer_payment_methods
 
   after_create :generate_token_attribute
 

--- a/spec/factories/customer_payment_methods.rb
+++ b/spec/factories/customer_payment_methods.rb
@@ -5,14 +5,17 @@ FactoryBot.define do
 
     trait :pix do
       payment_method { create(:payment_method, :pix) }
+      name { :pix }
     end
 
     trait :boleto do
       payment_method { create(:payment_method, :boleto) }
+      name { :boleto }
     end
 
     trait :credit_card do
       payment_method { create(:payment_method, :credit_card) }
+      name { :credit_card }
       credit_card_name { 'Credit Card 1' }
       credit_card_number { '4929513324664053' }
       credit_card_expiration_date { 3.months.from_now }

--- a/spec/requests/api/customer_api_spec.rb
+++ b/spec/requests/api/customer_api_spec.rb
@@ -57,6 +57,30 @@ describe 'Customer API' do
       expect(parsed_body[:customer][:token]).to_not eq(customer2.token)
     end
 
+    it 'should get customer 1 with customer payment method' do
+      owner = create(:user, :complete_company_owner)
+      owner.company.accepted!
+
+      customer1 = create(:customer, company: owner.company)
+      customer2 = create(:customer, company: owner.company)
+
+      customer_payment_method = create(:customer_payment_method, :pix, customer: customer1, company: owner.company)
+
+      get "/api/v1/customer/#{customer1.token}", headers: { companyToken: owner.company.token }
+
+      expect(response).to have_http_status(200)
+      expect(response.content_type).to include('application/json')
+      expect(parsed_body[:customer][:name]).to eq(customer1.name)
+      expect(parsed_body[:customer][:cpf]).to eq(customer1.cpf)
+      expect(parsed_body[:customer][:token]).to eq(customer1.token)
+      ###
+      expect(parsed_body[:customer][:customer_payment_methods][0][:name]).to eq(customer_payment_method.name)
+      expect(parsed_body[:customer][:customer_payment_methods][0][:token]).to eq(customer_payment_method.token)
+      ###
+      expect(parsed_body[:customer][:company][:legal_name]).to eq(owner.company.legal_name)
+      expect(parsed_body[:customer][:token]).to_not eq(customer2.token)
+    end
+
     it 'should return 404 if setting does not exist' do
       owner = create(:user, :complete_company_owner)
       company = owner.company

--- a/spec/requests/api/customer_api_spec.rb
+++ b/spec/requests/api/customer_api_spec.rb
@@ -73,10 +73,8 @@ describe 'Customer API' do
       expect(parsed_body[:customer][:name]).to eq(customer1.name)
       expect(parsed_body[:customer][:cpf]).to eq(customer1.cpf)
       expect(parsed_body[:customer][:token]).to eq(customer1.token)
-      ###
       expect(parsed_body[:customer][:customer_payment_methods][0][:name]).to eq(customer_payment_method.name)
       expect(parsed_body[:customer][:customer_payment_methods][0][:token]).to eq(customer_payment_method.token)
-      ###
       expect(parsed_body[:customer][:company][:legal_name]).to eq(owner.company.legal_name)
       expect(parsed_body[:customer][:token]).to_not eq(customer2.token)
     end


### PR DESCRIPTION
PR bem simples pra mostrar customer_payment_method no show de customer.

- Isso permite que a empresa, consultando a api, obtenha o customer_payment_method_token, que vai ser passado, por exemplo, pra fazer uma compra ou assinatura

- Por enquanto, em transaction e não na main

resolve #69 