### PR TITLE
Subscription renewal

### DIFF
--- a/app/models/customer_subscription.rb
+++ b/app/models/customer_subscription.rb
@@ -22,25 +22,19 @@ class CustomerSubscription < ApplicationRecord
       today: today, pending: statuses[:pending]
     )
 
-    today_subscriptions.each do |s|
-      Purchase.create(company: s.company, customer_payment_method: s.customer_payment_method,
-                      product: s.product, cost: s.cost, expiration_date: today)
-    end
+    create_today_purchases(today_subscriptions, today)
   end
 
+  # TODO: chamar esse metodo no Purchase quando for aprovada
   def self.retry_purchase_creation(customer_payment_method:, product:)
-    customer_subscription = CustomerSubscription.find_by(customer_payment_method: customer_payment_method,
-                                                          product: product)
-    if customer_subscription.tried_renew_times < 2
-      customer_subscription.retry_date = Time.zone.today + 2.days
-      customer_subscription.tried_renew_times += 1
-      customer_subscription.status = 'pending'
-    else
-      customer_subscription.tried_renew_times += 1
-      customer_subscription.status = 'canceled'
-    end
+    customer_subscription = CustomerSubscription.find_by(
+      customer_payment_method: customer_payment_method,
+      product: product
+    )
 
-    customer_subscription.save!
+    return handle_retry_renovation(customer_subscription) if customer_subscription.tried_renew_times < 2
+
+    handle_cancel_subscription(customer_subscription)
   end
 
   def validate_product_is_not_single
@@ -54,5 +48,30 @@ class CustomerSubscription < ApplicationRecord
   def create_renovation_date
     today = Time.zone.today.day
     self.renovation_date = today > 28 ? 1 : today
+  end
+
+  class << self
+    def create_today_purchases(today_subscriptions, today)
+      today_subscriptions.each do |s|
+        Purchase.create(company: s.company, customer_payment_method: s.customer_payment_method,
+                        product: s.product, cost: s.cost, expiration_date: today)
+      end
+    end
+
+    # TODO: resetar esses atributos quando alterar de pendente/cancelada para ativa
+    def handle_retry_renovation(customer_subscription)
+      customer_subscription.retry_date = Time.zone.today + 2.days
+      customer_subscription.tried_renew_times += 1
+      customer_subscription.status = 'pending'
+
+      customer_subscription.save!
+    end
+
+    def handle_cancel_subscription(customer_subscription)
+      customer_subscription.tried_renew_times += 1
+      customer_subscription.status = 'canceled'
+
+      customer_subscription.save!
+    end
   end
 end

--- a/db/migrate/20211203013708_add_retry_date_and_tried_renew_times_to_customer_subscription.rb
+++ b/db/migrate/20211203013708_add_retry_date_and_tried_renew_times_to_customer_subscription.rb
@@ -1,0 +1,6 @@
+class AddRetryDateAndTriedRenewTimesToCustomerSubscription < ActiveRecord::Migration[6.1]
+  def change
+    add_column :customer_subscriptions, :retry_date, :date
+    add_column :customer_subscriptions, :tried_renew_times, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_12_02_133350) do
+ActiveRecord::Schema.define(version: 2021_12_03_013708) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -124,6 +124,8 @@ ActiveRecord::Schema.define(version: 2021_12_02_133350) do
     t.integer "company_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.date "retry_date"
+    t.integer "tried_renew_times", default: 0
     t.index ["company_id"], name: "index_customer_subscriptions_on_company_id"
     t.index ["customer_payment_method_id"], name: "index_customer_subscriptions_on_customer_payment_method_id"
     t.index ["product_id"], name: "index_customer_subscriptions_on_product_id"

--- a/spec/models/customer_subscription_spec.rb
+++ b/spec/models/customer_subscription_spec.rb
@@ -95,14 +95,14 @@ RSpec.describe CustomerSubscription, type: :model do
     end
 
     it 'should create purchases for pending subscriptions at retry date' do
-      date = Date.new(2021, 12, 01)
+      date = Date.new(2021, 12, 0o1)
       next_renovation = date + 1.month
       customer_subscription = nil
 
       travel_to date do
         customer_subscription = create(
           :customer_subscription, retry_date: next_renovation + 2.days,
-          tried_renew_times: 1, status: 'pending'
+                                  tried_renew_times: 1, status: 'pending'
         )
       end
 
@@ -125,7 +125,7 @@ RSpec.describe CustomerSubscription, type: :model do
   # esse metodo seria chamado pela cobrança (Purchase), quando a cobrança fosse recusada
   context '.retry_purchase_creation' do
     it 'should set retry_date to 2 days later' do
-      date = Date.new(2021, 12, 01)
+      date = Date.new(2021, 12, 0o1)
       customer_subscription = nil
 
       travel_to date do
@@ -146,14 +146,14 @@ RSpec.describe CustomerSubscription, type: :model do
     end
 
     it 'should set retry_date to 4 days later' do
-      date = Date.new(2021, 12, 01)
+      date = Date.new(2021, 12, 0o1)
       next_renovation = date + 1.month
       customer_subscription = nil
 
       travel_to date do
         customer_subscription = create(
           :customer_subscription, retry_date: next_renovation + 2.days,
-          tried_renew_times: 1, status: 'pending'
+                                  tried_renew_times: 1, status: 'pending'
         )
       end
 
@@ -171,14 +171,14 @@ RSpec.describe CustomerSubscription, type: :model do
     end
 
     it 'should cancel subscription after 5 days' do
-      date = Date.new(2021, 12, 01)
+      date = Date.new(2021, 12, 0o1)
       next_renovation = date + 1.month
       customer_subscription = nil
 
       travel_to date do
         customer_subscription = create(
           :customer_subscription, retry_date: next_renovation + 4.days,
-          tried_renew_times: 2, status: 'pending'
+                                  tried_renew_times: 2, status: 'pending'
         )
       end
 


### PR DESCRIPTION
Adiciona métodos em CustomerSubscription para criação de cobranças e agenda retentativa de cobrança

- CustomerSubscription.renew_subscriptions cria cobranças para assinaturas ativas naquele dia e tentativas agendadas para aquele dia
- CustomerSubscription.retry_purchase_creation coloca um atributo retry_date para dois dias após o dia em que a cobrança falhou. A assinatura é então colocada no status pending
- Após falhar 3 vezes (atributo tried_renew_times), a assinatura é colocada no status cancelada

- TODOs (provavelmente vai ficar no backlog)
  * chamar renew_subscriptions quando a Purchase é aprovada
  * mudar o status para ativa quando a assinatura pendente/cancelada for paga